### PR TITLE
fixed setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "evaluate_functional_correctness = verilog_eval.evaluate_functional_correctness",
+            "evaluate_functional_correctness = verilog_eval.evaluate_functional_correctness:main",
         ]
     }
 )


### PR DESCRIPTION
Was getting the following error.

```zsh
ERROR: For req: verilog-eval==1.0. Invalid script entry point: <ExportEntry evaluate_functional_correctness = verilog_eval.evaluate_functional_correctness:None []> - A callable suffix is required. Cf https://packaging.python.org/specifications/entry-points/#use-for-scripts for more information.
```

Fixed it now :)