### PR TITLE
Fix for several problems in dataset

### DIFF
--- a/dataset_code-complete-iccad2023/Prob118_history_shift_ref.sv
+++ b/dataset_code-complete-iccad2023/Prob118_history_shift_ref.sv
@@ -13,8 +13,8 @@ module RefModule (
 
   always@(posedge clk, posedge areset)
     if (areset) begin
-      predict_history = 0;
-        end  else begin
+      predict_history <= 0;
+    end else begin
       if (train_mispredicted)
         predict_history <= {train_history, train_taken};
       else if (predict_valid)

--- a/dataset_code-complete-iccad2023/Prob134_2014_q3c_ifc.txt
+++ b/dataset_code-complete-iccad2023/Prob134_2014_q3c_ifc.txt
@@ -1,6 +1,5 @@
 
 module TopModule (
-  input clk,
   input x,
   input [2:0] y,
   output reg Y0,

--- a/dataset_code-complete-iccad2023/Prob134_2014_q3c_prompt.txt
+++ b/dataset_code-complete-iccad2023/Prob134_2014_q3c_prompt.txt
@@ -10,7 +10,6 @@ Y[0] and z.
    100 | 011, 100 | 1
 
 module TopModule (
-  input clk,
   input x,
   input [2:0] y,
   output reg Y0,

--- a/dataset_code-complete-iccad2023/Prob134_2014_q3c_ref.sv
+++ b/dataset_code-complete-iccad2023/Prob134_2014_q3c_ref.sv
@@ -1,6 +1,5 @@
 
 module RefModule (
-  input clk,
   input x,
   input [2:0] y,
   output reg Y0,

--- a/dataset_code-complete-iccad2023/Prob134_2014_q3c_test.sv
+++ b/dataset_code-complete-iccad2023/Prob134_2014_q3c_test.sv
@@ -66,14 +66,12 @@ module tb();
 		.x,
 		.y );
 	RefModule good1 (
-		.clk,
 		.x,
 		.y,
 		.Y0(Y0_ref),
 		.z(z_ref) );
 		
 	TopModule top_module1 (
-		.clk,
 		.x,
 		.y,
 		.Y0(Y0_dut),

--- a/dataset_code-complete-iccad2023/Prob153_gshare_ref.sv
+++ b/dataset_code-complete-iccad2023/Prob153_gshare_ref.sv
@@ -27,9 +27,9 @@ module RefModule (
   always@(posedge clk, posedge areset)
     if (areset) begin
       for (integer i=0; i<2**n; i=i+1)
-        pht[i] = LNT;
-      predict_history_r = 0;
-        end  else begin
+        pht[i] <= LNT;
+      predict_history_r <= 0;
+    end else begin
       if (predict_valid)
         predict_history_r <= {predict_history_r, predict_taken};
       if(train_valid) begin

--- a/dataset_spec-to-rtl/Prob099_m2014_q6c_test.sv
+++ b/dataset_spec-to-rtl/Prob099_m2014_q6c_test.sv
@@ -28,10 +28,10 @@ module tb();
 	typedef struct packed {
 		int errors;
 		int errortime;
-		int errors_Y2;
-		int errortime_Y2;
-		int errors_Y4;
-		int errortime_Y4;
+		int errors_Y1;
+		int errortime_Y1;
+		int errors_Y3;
+		int errortime_Y3;
 
 		int clocks;
 	} stats;
@@ -49,14 +49,14 @@ module tb();
 
 	logic [6:1] y;
 	logic w;
-	logic Y2_ref;
-	logic Y2_dut;
-	logic Y4_ref;
-	logic Y4_dut;
+	logic Y1_ref;
+	logic Y1_dut;
+	logic Y3_ref;
+	logic Y3_dut;
 
 	initial begin 
 		$dumpfile("wave.vcd");
-		$dumpvars(1, stim1.clk, tb_mismatch ,y,w,Y2_ref,Y2_dut,Y4_ref,Y4_dut );
+		$dumpvars(1, stim1.clk, tb_mismatch ,y,w,Y1_ref,Y1_dut,Y3_ref,Y3_dut );
 	end
 
 
@@ -71,14 +71,14 @@ module tb();
 	RefModule good1 (
 		.y,
 		.w,
-		.Y2(Y2_ref),
-		.Y4(Y4_ref) );
+		.Y1(Y1_ref),
+		.Y3(Y3_ref) );
 		
 	TopModule top_module1 (
 		.y,
 		.w,
-		.Y2(Y2_dut),
-		.Y4(Y4_dut) );
+		.Y1(Y1_dut),
+		.Y3(Y3_dut) );
 
 	
 	bit strobe = 0;
@@ -91,10 +91,10 @@ module tb();
 
 	
 	final begin
-		if (stats1.errors_Y2) $display("Hint: Output '%s' has %0d mismatches. First mismatch occurred at time %0d.", "Y2", stats1.errors_Y2, stats1.errortime_Y2);
-		else $display("Hint: Output '%s' has no mismatches.", "Y2");
-		if (stats1.errors_Y4) $display("Hint: Output '%s' has %0d mismatches. First mismatch occurred at time %0d.", "Y4", stats1.errors_Y4, stats1.errortime_Y4);
-		else $display("Hint: Output '%s' has no mismatches.", "Y4");
+		if (stats1.errors_Y1) $display("Hint: Output '%s' has %0d mismatches. First mismatch occurred at time %0d.", "Y1", stats1.errors_Y1, stats1.errortime_Y1);
+		else $display("Hint: Output '%s' has no mismatches.", "Y1");
+		if (stats1.errors_Y3) $display("Hint: Output '%s' has %0d mismatches. First mismatch occurred at time %0d.", "Y3", stats1.errors_Y3, stats1.errortime_Y3);
+		else $display("Hint: Output '%s' has no mismatches.", "Y3");
 
 		$display("Hint: Total mismatched samples is %1d out of %1d samples\n", stats1.errors, stats1.clocks);
 		$display("Simulation finished at %0d ps", $time);
@@ -102,7 +102,7 @@ module tb();
 	end
 	
 	// Verification: XORs on the right makes any X in good_vector match anything, but X in dut_vector will only match X.
-	assign tb_match = ( { Y2_ref, Y4_ref } === ( { Y2_ref, Y4_ref } ^ { Y2_dut, Y4_dut } ^ { Y2_ref, Y4_ref } ) );
+	assign tb_match = ( { Y1_ref, Y3_ref } === ( { Y1_ref, Y3_ref } ^ { Y1_dut, Y3_dut } ^ { Y1_ref, Y3_ref } ) );
 	// Use explicit sensitivity list here. @(*) causes NetProc::nex_input() to be called when trying to compute
 	// the sensitivity list of the @(strobe) process, which isn't implemented.
 	always @(posedge clk, negedge clk) begin
@@ -112,12 +112,12 @@ module tb();
 			if (stats1.errors == 0) stats1.errortime = $time;
 			stats1.errors++;
 		end
-		if (Y2_ref !== ( Y2_ref ^ Y2_dut ^ Y2_ref ))
-		begin if (stats1.errors_Y2 == 0) stats1.errortime_Y2 = $time;
-			stats1.errors_Y2 = stats1.errors_Y2+1'b1; end
-		if (Y4_ref !== ( Y4_ref ^ Y4_dut ^ Y4_ref ))
-		begin if (stats1.errors_Y4 == 0) stats1.errortime_Y4 = $time;
-			stats1.errors_Y4 = stats1.errors_Y4+1'b1; end
+		if (Y1_ref !== ( Y1_ref ^ Y1_dut ^ Y1_ref ))
+		begin if (stats1.errors_Y1 == 0) stats1.errortime_Y1 = $time;
+			stats1.errors_Y1 = stats1.errors_Y1+1'b1; end
+		if (Y3_ref !== ( Y3_ref ^ Y3_dut ^ Y3_ref ))
+		begin if (stats1.errors_Y3 == 0) stats1.errortime_Y3 = $time;
+			stats1.errors_Y3 = stats1.errors_Y3+1'b1; end
 
 	end
 

--- a/dataset_spec-to-rtl/Prob118_history_shift_ref.sv
+++ b/dataset_spec-to-rtl/Prob118_history_shift_ref.sv
@@ -13,8 +13,8 @@ module RefModule (
 
   always@(posedge clk, posedge areset)
     if (areset) begin
-      predict_history = 0;
-        end  else begin
+      predict_history <= 0;
+    end else begin
       if (train_mispredicted)
         predict_history <= {train_history, train_taken};
       else if (predict_valid)

--- a/dataset_spec-to-rtl/Prob134_2014_q3c_prompt.txt
+++ b/dataset_spec-to-rtl/Prob134_2014_q3c_prompt.txt
@@ -3,7 +3,6 @@ I would like you to implement a module named TopModule with the following
 interface. All input and output ports are one bit unless otherwise
 specified.
 
- - input  clk
  - input  x
  - input  y (3 bits)
  - output Y0

--- a/dataset_spec-to-rtl/Prob134_2014_q3c_ref.sv
+++ b/dataset_spec-to-rtl/Prob134_2014_q3c_ref.sv
@@ -1,6 +1,5 @@
 
 module RefModule (
-  input clk,
   input x,
   input [2:0] y,
   output reg Y0,

--- a/dataset_spec-to-rtl/Prob134_2014_q3c_test.sv
+++ b/dataset_spec-to-rtl/Prob134_2014_q3c_test.sv
@@ -66,14 +66,12 @@ module tb();
 		.x,
 		.y );
 	RefModule good1 (
-		.clk,
 		.x,
 		.y,
 		.Y0(Y0_ref),
 		.z(z_ref) );
 		
 	TopModule top_module1 (
-		.clk,
 		.x,
 		.y,
 		.Y0(Y0_dut),

--- a/dataset_spec-to-rtl/Prob135_m2014_q6b_prompt.txt
+++ b/dataset_spec-to-rtl/Prob135_m2014_q6b_prompt.txt
@@ -7,7 +7,8 @@ specified.
  - input  w
  - output Y1
 
-The module should implement the state machine shown below:
+The module should implement part of the next-state logic in the state
+machine shown below:
 
   A (0) --0--> B
   A (0) --1--> A

--- a/dataset_spec-to-rtl/Prob153_gshare_ref.sv
+++ b/dataset_spec-to-rtl/Prob153_gshare_ref.sv
@@ -27,9 +27,9 @@ module RefModule (
   always@(posedge clk, posedge areset)
     if (areset) begin
       for (integer i=0; i<2**n; i=i+1)
-        pht[i] = LNT;
-      predict_history_r = 0;
-        end  else begin
+        pht[i] <= LNT;
+      predict_history_r <= 0;
+    end else begin
       if (predict_valid)
         predict_history_r <= {predict_history_r, predict_taken};
       if(train_valid) begin


### PR DESCRIPTION
This PR addresses a set of fixes span across the testbenches, reference RTL, and prompts to improve correctness and clarity.

Summary of flaws and proposed fixes:
1. Prob 099: DUT initiation port mismatch (Changed Testbench)
2. Prob 118 & 153: Using blocking assignment in sequencial logic (Changed Reference RTL)
3. Prob 134: Unused input clk port (Changed Prompt + v1 interface + Reference RTL + Testbench)
4. Prob 135: Not the FSM itself but the next-state logic should be implemented (Changed v2 Prompt)

All feedbacks are welcome! We're more than happy to discuss these changes further to ensure they align with the benchmark motivation and standards.