### PR TITLE
Initialize flip-flops with undefined reset value to x

### DIFF
--- a/dataset_code-complete-iccad2023/Prob053_m2014_q4d_ref.sv
+++ b/dataset_code-complete-iccad2023/Prob053_m2014_q4d_ref.sv
@@ -6,7 +6,7 @@ module RefModule (
 );
 
   initial
-    out = 0;
+    out = 1'hx;
 
   always@(posedge clk) begin
     out <= in ^ out;

--- a/dataset_code-complete-iccad2023/Prob104_mt2015_muxdff_ref.sv
+++ b/dataset_code-complete-iccad2023/Prob104_mt2015_muxdff_ref.sv
@@ -7,7 +7,7 @@ module RefModule (
   output reg Q
 );
 
-  initial Q=0;
+  initial Q=1'hx;
   always @(posedge clk)
     Q <= L ? r_in : q_in;
 

--- a/dataset_spec-to-rtl/Prob034_dff8_ref.sv
+++ b/dataset_spec-to-rtl/Prob034_dff8_ref.sv
@@ -6,7 +6,7 @@ module RefModule (
 );
 
   initial
-    q = 8'h0;
+    q = 8'hx;
 
   always @(posedge clk)
     q <= d;

--- a/dataset_spec-to-rtl/Prob053_m2014_q4d_ref.sv
+++ b/dataset_spec-to-rtl/Prob053_m2014_q4d_ref.sv
@@ -6,7 +6,7 @@ module RefModule (
 );
 
   initial
-    out = 0;
+    out = 1'hx;
 
   always@(posedge clk) begin
     out <= in ^ out;

--- a/dataset_spec-to-rtl/Prob104_mt2015_muxdff_ref.sv
+++ b/dataset_spec-to-rtl/Prob104_mt2015_muxdff_ref.sv
@@ -7,7 +7,7 @@ module RefModule (
   output reg Q
 );
 
-  initial Q=0;
+  initial Q=1'hx;
   always @(posedge clk)
     Q <= L ? r_in : q_in;
 


### PR DESCRIPTION
From v1 to v2, [Prob034](https://github.com/NVlabs/verilog-eval/blob/main/dataset_code-complete-iccad2023/Prob034_dff8_ref.sv) was updated with the fix from #8 in code-complete-iccad2023, but not in spec-to-rtl. Additionally, problems 053 and 104 have DFFs initialized to 0, but this is not specified anywhere in the problem (so I initialize them to x instead).